### PR TITLE
fix dimension layout of decoupling objective gradient and hessian

### DIFF
--- a/+control/+design/+gamma/private/calculate_objective_decoupling.m
+++ b/+control/+design/+gamma/private/calculate_objective_decoupling.m
@@ -90,7 +90,7 @@ function [J, gradJ, hessJ] = calculate_objective_decoupling(R, ~, F, systems, di
 						if needsgradient
 							gradJ_decoupling_temp_parfor = gradJ_decoupling_temp_parfor + 2*[
 								r.'*(X_R.'*X_R) - z_R.'*X_R, zeros(1, number_controls*number_measurements_xdot), zeros(1, (jj - 1)*number_controls), f.'*(X_F.'*X_F), zeros(1, (number_references - jj)*number_controls)
-							].';
+							];
 						end
 						if needshessian
 							hessJ_tmp = 2*blkdiag(...
@@ -100,7 +100,7 @@ function [J, gradJ, hessJ] = calculate_objective_decoupling(R, ~, F, systems, di
 								X_F.'*X_F,...
 								zeros((number_references - jj)*number_controls, (number_references - jj)*number_controls)...
 							);
-							hessJ_decoupling_temp_parfor = hessJ_decoupling_temp_parfor + hessJ_tmp;
+							hessJ_decoupling_temp_parfor = hessJ_decoupling_temp_parfor + reshape(hessJ_tmp, 1, size(hessJ_tmp, 1), size(hessJ_tmp, 2));
 						end
 					end
 					J_decoupling_temp(ii, 1) = J_decoupling_temp_parfor;


### PR DESCRIPTION
Fixes dimension layout of decoupling objective gradient and hessian for codegeneration in R2023B and newer.

**By submitting this pull request, I confirm the following:**
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pvogt09/gammasyn/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [LGPL 3 license](https://www.gnu.org/licenses/lgpl-3.0.en.html)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you Sign Off all commits.
This repository enforces the DCO.

---
**What does this PR aim to accomplish?:**
Fix the layout of gradient and hessian for decoupling onjective with Matlab versions >= R2023B.


**How does this PR accomplish the above?:**
Transpose gradient and reshape hessian to 3D matrix.


**What documentation changes (if any) are needed to support this PR?:**
None.